### PR TITLE
Update extension-meta.php

### DIFF
--- a/extension-meta.php
+++ b/extension-meta.php
@@ -48,7 +48,8 @@ class WshWordPressPackageParser {
 			$fileName = trim(str_replace('\\', '/', $info['name']), '/');
 			$fileName = ltrim($fileName, '/');
 
-			$extension = strtolower(end(explode('.', $fileName)));
+			$explode = explode('.', $fileName);
+			$extension = strtolower(end($explode));
 			$depth = substr_count($fileName, '/');
 
 			//Skip empty files, directories and everything that's more than 1 sub-directory deep.


### PR DESCRIPTION
Solves "only variables should be passed by reference" error.

`end()` requires a reference because it modifies the internal representation of the array. The result of `explode('.', $fileName)` cannot be turned into a reference in PHP.

Assigning the result of `explode()` to a variable and passing that variable to `end()` solves the problem.